### PR TITLE
Fix inconsistency between XMLHttpRequest and fetch

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -119,7 +119,7 @@ ClientRequest.prototype._onFinish = function () {
 			headers: headers,
 			body: body,
 			mode: 'cors',
-			credentials: opts.withCredentials ? 'include' : 'omit'
+			credentials: opts.withCredentials ? 'include' : 'same-origin'
 		}).then(function (response) {
 			self._fetchResponse = response
 			self._connect()

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "basic-auth": "^1.0.3",
     "brfs": "^1.4.0",
+    "cookie-parser": "^1.3.5",
     "express": "^4.13.0",
     "tape": "^4.0.0",
     "ua-parser-js": "^0.7.7",

--- a/test/browser/cookie.js
+++ b/test/browser/cookie.js
@@ -1,0 +1,25 @@
+var Buffer = require('buffer').Buffer
+var test = require('tape')
+
+var http = require('../..')
+
+test('cookie', function (t) {
+  var cookie = 'hello=world'
+  window.document.cookie = cookie
+
+  http.get({
+    path: '/cookie',
+    withCredentials: false
+  }, function (res) {
+    var buffers = []
+
+    res.on('end', function () {
+      t.ok(new Buffer(cookie).equals(Buffer.concat(buffers)), 'hello cookie echoed')
+      t.end()
+    })
+
+    res.on('data', function (data) {
+      buffers.push(data)
+    })
+  })
+})

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -1,3 +1,4 @@
+var cookieParser = require('cookie-parser')
 var basicAuth = require('basic-auth')
 var express = require('express')
 var fs = require('fs')
@@ -43,6 +44,12 @@ app.get('/testHeaders', function (req, res) {
 	var body = JSON.stringify(reqHeaders)
 	res.setHeader('Content-Length', body.length)
 	res.write(body)
+	res.end()
+})
+
+app.get('/cookie', cookieParser(), function (req, res) {
+	res.setHeader('Content-Type', 'text/plain')
+	res.write('hello=' + req.cookies.hello)
 	res.end()
 })
 


### PR DESCRIPTION
Change fetch credentials option from omit to same-origin, to be consistent with XMLHttpRequest.

Setting XMLHttpRequest.withCredentials to false has [no effect on same-site requests](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#xmlhttprequest-withcredentials). In order to have consistent behavior with XMLHttpRequest, fetch credentials should be set to same-origin when withCredentials is false.

Reverting 5fc4858 will cause the newly added test to fail on:

Browser: Google Chrome Version 43.0.2357.134 (64-bit)
Operating System: OS X 10.10.4
