### PR TITLE
Fixed bug when using req.end(data)

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -245,7 +245,7 @@ ClientRequest.prototype.end = function (data, encoding, cb) {
 	}
 
 	if (data)
-		stream.Writable.push.call(self, data, encoding)
+		stream.Writable.prototype.write.call(self, data, encoding)
 
 	stream.Writable.prototype.end.call(self, cb)
 }


### PR DESCRIPTION
When doing something like this; 

var req = https.request(configObj, function(response) {...});
req.end(data);

The current stream-http will fail with the error: "Uncaught TypeError: Cannot read property 'call' of undefined", referring to the line I changed (stream.Writable.push.call(self, data, encoding)) - a line I can't make sense of since Writable is a function. 

With my proposed change the code now works as expected. 
