### PR TITLE
Set protocol to https in case browserify-https delegates to us.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,9 @@ http.request = function (opts, cb) {
 	opts.method = opts.method || 'GET'
 	opts.headers = opts.headers || {}
 	opts.path = opts.path || '/'
-	opts.protocol = opts.protocol || window.location.protocol
+	// https-browserify deelegates to us and sets ops.scheme to 'https'
+	var scheme = opts.scheme ? opts.scheme + ':' : null
+	opts.protocol = opts.protocol || scheme || window.location.protocol
 	// If the hostname is provided, use the default port for the protocol. If
 	// the url is instead relative, use window.location.port
 	var defaultPort = (opts.hostname || hostHostname) ? (opts.protocol === 'https:' ? 443 : 80) : window.location.port


### PR DESCRIPTION
Fixes bug when an `https` request is made by a page loaded via `http`. (See also  substack/hyperquest#51 and  discussion at substack/hyperquest#52)