### PR TITLE
Use `url.resolve` for relative path handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,19 +11,20 @@ http.request = function (opts, cb) {
 	else
 		opts = extend(opts)
 
-	// Split opts.host into its components
-	var hostHostname = opts.host ? opts.host.split(':')[0] : null
-	var hostPort = opts.host ? parseInt(opts.host.split(':')[1], 10) : null
+	var protocol = opts.protocol || ''
+	var host = opts.hostname || opts.host
+	var port = opts.port
+	var path = opts.path || '/'
 
-	opts.method = opts.method || 'GET'
+	// Necessary for IPv6 addresses
+	if (host && host.indexOf(':') !== -1)
+		host = '[' + host + ']'
+
+	var requestUrl = (host ? (protocol + '//' + host) : '') + (port ? ':' + port : '') + path
+
+	opts.url = url.resolve(window.location.toString(), requestUrl)
+	opts.method = (opts.method || 'GET').toUpperCase()
 	opts.headers = opts.headers || {}
-	opts.path = opts.path || '/'
-	opts.protocol = opts.protocol || window.location.protocol
-	// If the hostname is provided, use the default port for the protocol. If
-	// the url is instead relative, use window.location.port
-	var defaultPort = (opts.hostname || hostHostname) ? (opts.protocol === 'https:' ? 443 : 80) : window.location.port
-	opts.hostname = opts.hostname || hostHostname || window.location.hostname
-	opts.port = opts.port || hostPort || defaultPort
 
 	// Also valid opts.auth, opts.mode
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -31,8 +31,6 @@ var ClientRequest = module.exports = function (opts) {
 	stream.Writable.call(self)
 
 	self._opts = opts
-	var hostname = opts.hostname.indexOf(':') === -1 ? opts.hostname : '[' + opts.hostname + ']'
-	self._url = opts.protocol + '//' + hostname + ':' + opts.port + opts.path
 	self._body = []
 	self._headers = {}
 	if (opts.auth)
@@ -116,7 +114,7 @@ ClientRequest.prototype._onFinish = function () {
 			return [headersObj[name].name, headersObj[name].value]
 		})
 
-		window.fetch(self._url, {
+		window.fetch(self._opts.url, {
 			method: self._opts.method,
 			headers: headers,
 			body: body,
@@ -131,7 +129,7 @@ ClientRequest.prototype._onFinish = function () {
 	} else {
 		var xhr = self._xhr = new window.XMLHttpRequest()
 		try {
-			xhr.open(self._opts.method, self._url, true)
+			xhr.open(self._opts.method, self._opts.url, true)
 		} catch (err) {
 			process.nextTick(function () {
 				self.emit('error', err)

--- a/test/node/http-browserify.js
+++ b/test/node/http-browserify.js
@@ -3,7 +3,7 @@
 var test = require('tape')
 
 global.window = {}
-window.location = 'http://localhost:8081'
+window.location = 'http://localhost:8081/foo/123'
 
 var noop = function() {}
 window.XMLHttpRequest = function() {
@@ -88,6 +88,14 @@ test('Test ipv6 address', function(t) {
 	var request = http.get(url, noop)
 
 	t.equal(request._opts.url, 'http://[::1]:80/foo', 'Url should be correct')
+	t.end()
+})
+
+test('Test relative path in url', function(t) {
+	var params = { path: './bar' }
+	var request = http.get(params, noop)
+
+	t.equal(request._opts.url, 'http://localhost:8081/foo/bar', 'Url should be correct')
 	t.end()
 })
 

--- a/test/node/http-browserify.js
+++ b/test/node/http-browserify.js
@@ -3,11 +3,7 @@
 var test = require('tape')
 
 global.window = {}
-window.location = {
-		hostname: 'localhost',
-		port: 8081,
-		protocol: 'http:'
-}
+window.location = 'http://localhost:8081'
 
 var noop = function() {}
 window.XMLHttpRequest = function() {
@@ -24,7 +20,7 @@ test('Test simple url string', function(t) {
 	var url = { path: '/api/foo' }
 	var request = http.get(url, noop)
 
-	t.equal(request._url, 'http://localhost:8081/api/foo', 'Url should be correct')
+	t.equal(request._opts.url, 'http://localhost:8081/api/foo', 'Url should be correct')
 	t.end()
 
 })
@@ -46,7 +42,7 @@ test('Test full url object', function(t) {
 
 	var request = http.get(url, noop)
 
-	t.equal(request._url, 'http://localhost:8081/api/foo?bar=baz', 'Url should be correct')
+	t.equal(request._opts.url, 'http://localhost:8081/api/foo?bar=baz', 'Url should be correct')
 	t.end()
 })
 
@@ -60,7 +56,7 @@ test('Test alt protocol', function(t) {
 
 	var request = http.get(params, noop)
 
-	t.equal(request._url, 'foo://localhost:3000/bar', 'Url should be correct')
+	t.equal(request._opts.url, 'foo://localhost:3000/bar', 'Url should be correct')
 	t.end()
 })
 
@@ -68,7 +64,7 @@ test('Test string as parameters', function(t) {
 	var url = '/api/foo'
 	var request = http.get(url, noop)
 
-	t.equal(request._url, 'http://localhost:8081/api/foo', 'Url should be correct')
+	t.equal(request._opts.url, 'http://localhost:8081/api/foo', 'Url should be correct')
 	t.end()
 })
 
@@ -91,7 +87,7 @@ test('Test ipv6 address', function(t) {
 	var url = 'http://[::1]:80/foo'
 	var request = http.get(url, noop)
 
-	t.equal(request._url, 'http://[::1]:80/foo', 'Url should be correct')
+	t.equal(request._opts.url, 'http://[::1]:80/foo', 'Url should be correct')
 	t.end()
 })
 


### PR DESCRIPTION
This simplifies url handling, but is currently broken in IE8; see https://github.com/defunctzombie/node-url/issues/6