### PR TITLE
Add support for relative paths in urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,19 +11,19 @@ http.request = function (opts, cb) {
 	else
 		opts = extend(opts)
 
-	// Split opts.host into its components
-	var hostHostname = opts.host ? opts.host.split(':')[0] : null
-	var hostPort = opts.host ? parseInt(opts.host.split(':')[1], 10) : null
+	var protocol = opts.protocol || ''
+	var host = opts.hostname || opts.host
+	var port = opts.port
+	var path = opts.path || '/'
 
-	opts.method = opts.method || 'GET'
+	// Necessary for IPv6 addresses
+	if (host && host.indexOf(':') !== -1)
+		host = '[' + host + ']'
+
+	// This may be a relative url. The browser should always be able to interpret it correctly.
+	opts.url = (host ? (protocol + '//' + host) : '') + (port ? ':' + port : '') + path
+	opts.method = (opts.method || 'GET').toUpperCase()
 	opts.headers = opts.headers || {}
-	opts.path = opts.path || '/'
-	opts.protocol = opts.protocol || window.location.protocol
-	// If the hostname is provided, use the default port for the protocol. If
-	// the url is instead relative, use window.location.port
-	var defaultPort = (opts.hostname || hostHostname) ? (opts.protocol === 'https:' ? 443 : 80) : window.location.port
-	opts.hostname = opts.hostname || hostHostname || window.location.hostname
-	opts.port = opts.port || hostPort || defaultPort
 
 	// Also valid opts.auth, opts.mode
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -31,8 +31,6 @@ var ClientRequest = module.exports = function (opts) {
 	stream.Writable.call(self)
 
 	self._opts = opts
-	var hostname = opts.hostname.indexOf(':') === -1 ? opts.hostname : '[' + opts.hostname + ']'
-	self._url = opts.protocol + '//' + hostname + ':' + opts.port + opts.path
 	self._body = []
 	self._headers = {}
 	if (opts.auth)
@@ -116,7 +114,7 @@ ClientRequest.prototype._onFinish = function () {
 			return [headersObj[name].name, headersObj[name].value]
 		})
 
-		window.fetch(self._url, {
+		window.fetch(self._opts.url, {
 			method: self._opts.method,
 			headers: headers,
 			body: body,
@@ -131,7 +129,7 @@ ClientRequest.prototype._onFinish = function () {
 	} else {
 		var xhr = self._xhr = new window.XMLHttpRequest()
 		try {
-			xhr.open(self._opts.method, self._url, true)
+			xhr.open(self._opts.method, self._opts.url, true)
 		} catch (err) {
 			process.nextTick(function () {
 				self.emit('error', err)

--- a/test/node/http-browserify.js
+++ b/test/node/http-browserify.js
@@ -1,15 +1,12 @@
 // These tests are teken from http-browserify to ensure compatibility with
 // that module
 var test = require('tape')
+var url = require('url')
 
-global.window = {}
-window.location = {
-		hostname: 'localhost',
-		port: 8081,
-		protocol: 'http:'
-}
+var location = 'http://localhost:8081'
 
 var noop = function() {}
+global.window = {}
 window.XMLHttpRequest = function() {
 	this.open = noop
 	this.send = noop
@@ -21,16 +18,17 @@ delete require.cache[moduleName]
 var http = require('../../')
 
 test('Test simple url string', function(t) {
-	var url = { path: '/api/foo' }
-	var request = http.get(url, noop)
+	var testUrl = { path: '/api/foo' }
+	var request = http.get(testUrl, noop)
 
-	t.equal(request._url, 'http://localhost:8081/api/foo', 'Url should be correct')
+	var resolved = url.resolve(location, request._opts.url)
+	t.equal(resolved, 'http://localhost:8081/api/foo', 'Url should be correct')
 	t.end()
 
 })
 
 test('Test full url object', function(t) {
-	var url = {
+	var testUrl = {
 		host: "localhost:8081",
 		hostname: "localhost",
 		href: "http://localhost:8081/api/foo?bar=baz",
@@ -44,9 +42,10 @@ test('Test full url object', function(t) {
 		slashes: true
 	}
 
-	var request = http.get(url, noop)
+	var request = http.get(testUrl, noop)
 
-	t.equal(request._url, 'http://localhost:8081/api/foo?bar=baz', 'Url should be correct')
+	var resolved = url.resolve(location, request._opts.url)
+	t.equal(resolved, 'http://localhost:8081/api/foo?bar=baz', 'Url should be correct')
 	t.end()
 })
 
@@ -60,15 +59,17 @@ test('Test alt protocol', function(t) {
 
 	var request = http.get(params, noop)
 
-	t.equal(request._url, 'foo://localhost:3000/bar', 'Url should be correct')
+	var resolved = url.resolve(location, request._opts.url)
+	t.equal(resolved, 'foo://localhost:3000/bar', 'Url should be correct')
 	t.end()
 })
 
 test('Test string as parameters', function(t) {
-	var url = '/api/foo'
-	var request = http.get(url, noop)
+	var testUrl = '/api/foo'
+	var request = http.get(testUrl, noop)
 
-	t.equal(request._url, 'http://localhost:8081/api/foo', 'Url should be correct')
+	var resolved = url.resolve(location, request._opts.url)
+	t.equal(resolved, 'http://localhost:8081/api/foo', 'Url should be correct')
 	t.end()
 })
 
@@ -88,10 +89,11 @@ test('Test withCredentials param', function(t) {
 })
 
 test('Test ipv6 address', function(t) {
-	var url = 'http://[::1]:80/foo'
-	var request = http.get(url, noop)
+	var testUrl = 'http://[::1]:80/foo'
+	var request = http.get(testUrl, noop)
 
-	t.equal(request._url, 'http://[::1]:80/foo', 'Url should be correct')
+	var resolved = url.resolve(location, request._opts.url)
+	t.equal(resolved, 'http://[::1]:80/foo', 'Url should be correct')
 	t.end()
 })
 

--- a/test/node/http-browserify.js
+++ b/test/node/http-browserify.js
@@ -3,7 +3,7 @@
 var test = require('tape')
 var url = require('url')
 
-var location = 'http://localhost:8081'
+var location = 'http://localhost:8081/foo/123'
 
 var noop = function() {}
 global.window = {}
@@ -94,6 +94,15 @@ test('Test ipv6 address', function(t) {
 
 	var resolved = url.resolve(location, request._opts.url)
 	t.equal(resolved, 'http://[::1]:80/foo', 'Url should be correct')
+	t.end()
+})
+
+test('Test relative path in url', function(t) {
+	var params = { path: './bar' }
+	var request = http.get(params, noop)
+
+	var resolved = url.resolve(location, request._opts.url)
+	t.equal(resolved, 'http://localhost:8081/foo/bar', 'Url should be correct')
 	t.end()
 })
 


### PR DESCRIPTION
This also substantially simplifies the url handling logic in general by using the browser's native ability to resolve various forms of relative urls.