### PR TITLE
jspm Node support

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,12 @@
     "ua-parser-js": "^0.7.7",
     "webworkify": "^1.0.2",
     "zuul": "^3.1.0"
+  },
+  "jspm": {
+    "map": {
+      "./index.js": {
+        "node": "@node/http"
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR includes the necessary jspm configuration for this package to work in Node with the coming jspm 0.17 release, allowing this single package to provide both client and server support.

I completely understand if you'd rather not support this here, but it will simplify configuration for jspm users having it one place. There is no maintenance burden either as I would continue to maintain this personally.

Just let me know if you have any questions at all, and thanks for considering.