### PR TITLE
Catch all connection errors

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -123,6 +123,8 @@ ClientRequest.prototype._onFinish = function () {
 			self._connect()
 		}, function (reason) {
 			self.emit('error', reason)
+		}).catch(function(error) {
+			self.emit('error', error.message)
 		})
 	} else {
 		var xhr = self._xhr = new global.XMLHttpRequest()


### PR DESCRIPTION
Not all connections errors are caught using then: connection errors such as not connected network are ignored. This should fix this.