### PR TITLE
Fix for an exception which is accured when response undefined

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -143,9 +143,9 @@ IncomingMessage.prototype._onXHRProgress = function () {
 			}
 			break
 		case 'arraybuffer':
-			if (xhr.readyState !== rStates.DONE)
-				break
 			response = xhr.response
+			if (xhr.readyState !== rStates.DONE || !response)
+				break
 			self.push(new Buffer(new Uint8Array(response)))
 			break
 		case 'moz-chunked-arraybuffer': // take whole


### PR DESCRIPTION
A little bit details may it help to find more generic solution. I am developing some JS API that call REST web services. Mocha tests is used for testing. Browserify framework is used for building browser version. Browser version testing by PhantomJs. So all test is passed in Node and browser (Chrome) environments. But PhantomJs fails on these lines. Also if I try to debug this in Browser the method _onXHRProgress is not called at all.