### PR TITLE
Attempting to use forEach for consistency

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -36,14 +36,10 @@ var IncomingMessage = exports.IncomingMessage = function (xhr, response, mode) {
 		self.statusMessage = response.statusText
 		// backwards compatible version of for (<item> of <iterable>):
 		// for (var <item>,_i,_it = <iterable>[Symbol.iterator](); <item> = (_i = _it.next()).value,!_i.done;)
-		try {
-		    for (var header, _i, _it = response.headers[Symbol.iterator](); header = (_i = _it.next()).value, !_i.done;) {
-                        self.headers[header[0].toLowerCase()] = header[1]
-                        self.rawHeaders.push(header[0], header[1])
-                    }
-		} catch (e) {
-		    console.log(e);
-		}
+		response.headers.forEach(function (value, name) {
+                    self.headers[name.toLowerCase()] = value;
+                    self.rawHeaders.push(name, value);
+                });
 
 		// TODO: this doesn't respect backpressure. Once WritableStream is available, this can be fixed
 		var reader = response.body.getReader()

--- a/lib/response.js
+++ b/lib/response.js
@@ -36,8 +36,8 @@ var IncomingMessage = exports.IncomingMessage = function (xhr, response, mode) {
 		self.statusMessage = response.statusText
 		// backwards compatible version of for (<item> of <iterable>):
 		// for (var <item>,_i,_it = <iterable>[Symbol.iterator](); <item> = (_i = _it.next()).value,!_i.done;)
-		var _it = response.headers.iterator();
-		for (var _i = _it.next(); !_i.done;) {
+		var _it = response.headers[Symbol.iterator]();
+		for (var _i =  _it.next(); _i && !_i.done; _i =  _it.next()) {
 		        var header = _i.value;
 			self.headers[header[0].toLowerCase()] = header[1]
 			self.rawHeaders.push(header[0], header[1])

--- a/lib/response.js
+++ b/lib/response.js
@@ -36,7 +36,9 @@ var IncomingMessage = exports.IncomingMessage = function (xhr, response, mode) {
 		self.statusMessage = response.statusText
 		// backwards compatible version of for (<item> of <iterable>):
 		// for (var <item>,_i,_it = <iterable>[Symbol.iterator](); <item> = (_i = _it.next()).value,!_i.done;)
-		for (var header, _i, _it = response.headers[Symbol.iterator](); header = (_i = _it.next()).value, !_i.done;) {
+		var _it = response.headers.iterator();
+		for (var _i = _it.next(); !_i.done;) {
+		        var header = _i.value;
 			self.headers[header[0].toLowerCase()] = header[1]
 			self.rawHeaders.push(header[0], header[1])
 		}

--- a/lib/response.js
+++ b/lib/response.js
@@ -36,11 +36,13 @@ var IncomingMessage = exports.IncomingMessage = function (xhr, response, mode) {
 		self.statusMessage = response.statusText
 		// backwards compatible version of for (<item> of <iterable>):
 		// for (var <item>,_i,_it = <iterable>[Symbol.iterator](); <item> = (_i = _it.next()).value,!_i.done;)
-		var _it = response.headers[Symbol.iterator]();
-		for (var _i =  _it.next(); _i && !_i.done; _i =  _it.next()) {
-		        var header = _i.value;
-			self.headers[header[0].toLowerCase()] = header[1]
-			self.rawHeaders.push(header[0], header[1])
+		try {
+		    for (var header, _i, _it = response.headers[Symbol.iterator](); header = (_i = _it.next()).value, !_i.done;) {
+                        self.headers[header[0].toLowerCase()] = header[1]
+                        self.rawHeaders.push(header[0], header[1])
+                    }
+		} catch (e) {
+		    console.log(e);
 		}
 
 		// TODO: this doesn't respect backpressure. Once WritableStream is available, this can be fixed


### PR DESCRIPTION
Recent MS Windows 10 anniversary updates, seems to have fetch implementations. However, iterators are not supported (none listed on their [dev page](https://developer.microsoft.com/en-us/microsoft-edge/platform/documentation/dev-guide/performance/fetch-api/#headers) )

This change is to rely on ```forEach``` instead of iterators.