### PR TITLE
Allow using a mode to disable the use of fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ also be a bit slow. This was the default in versions of this module before 1.5.
 that isn't a single-byte ASCII or utf8 character) will be corrupted. Of course, this option
 is only safe for text data. May also cause the 'content-type' response header to be
 incorrectly reported (as 'text/plain; charset=x-user-defined').
+  * 'disable-fetch': Force the use of plain XHR regardless of the browser declaring a fetch
+capability. Preserves the correctness of binary data and the 'content-type' response header.
   * 'prefer-fast': Deprecated; now a synonym for 'default', which has the same performance
 characteristics as this mode did in versions before 1.5.
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -7,8 +7,8 @@ var toArrayBuffer = require('to-arraybuffer')
 var IncomingMessage = response.IncomingMessage
 var rStates = response.readyStates
 
-function decideMode (preferBinary) {
-	if (capability.fetch) {
+function decideMode (preferBinary, useFetch) {
+	if (capability.fetch && useFetch) {
 		return 'fetch'
 	} else if (capability.mozchunkedarraybuffer) {
 		return 'moz-chunked-arraybuffer'
@@ -37,7 +37,12 @@ var ClientRequest = module.exports = function (opts) {
 	})
 
 	var preferBinary
-	if (opts.mode === 'prefer-streaming') {
+	var useFetch = true
+	if (opts.mode === 'disable-fetch') {
+		// If the use of XHR should be preferred and includes preserving the 'content-type' header
+		useFetch = false
+		preferBinary = true
+	} else if (opts.mode === 'prefer-streaming') {
 		// If streaming is a high priority but binary compatibility and
 		// the accuracy of the 'content-type' header aren't
 		preferBinary = false
@@ -50,7 +55,7 @@ var ClientRequest = module.exports = function (opts) {
 	} else {
 		throw new Error('Invalid value for opts.mode')
 	}
-	self._mode = decideMode(preferBinary)
+	self._mode = decideMode(preferBinary, useFetch)
 
 	self.on('finish', function () {
 		self._onFinish()

--- a/test/browser/disable-fetch.js
+++ b/test/browser/disable-fetch.js
@@ -1,0 +1,37 @@
+var Buffer = require('buffer').Buffer
+var test = require('tape')
+
+var http = require('../..')
+
+test('disable fetch', function (t) {
+	var originalFetch
+	if (typeof fetch === 'function') {
+		originalFetch = fetch
+	}
+
+	var fetchCalled = false
+	fetch = function (input, options) {
+		fetchCalled = true
+		if (originalFetch) {
+			return originalFetch(input, options)
+		}
+	}
+
+	http.get({
+		path: '/browserify.png',
+		mode: 'disable-fetch'
+	}, function (res) {
+		t.ok(!fetchCalled, 'fetch was not called')
+
+		if (originalFetch) {
+			fetch = originalFetch
+		}
+
+		res.on('end', function () {
+			t.ok(res.headers['content-type'] === 'image/png', 'content-type was set correctly')
+			t.end()
+		})
+
+		res.on('data', function () {})
+	})
+})


### PR DESCRIPTION
Hey,

This should address being able to selectively disable fetch which should address the issue I opened a while ago (https://github.com/jhiesey/stream-http/issues/44). Sorry this has taken so long!

I've implemented it as a mode named "disable-fetch" for now which also sets preferBinary (as per the overall default) so that content-type headers are reliable. A test for the new mode is included.

Thanks, Alex J Burke.