### PR TITLE
Bump travis node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "4.1"
+  - "6.4"


### PR DESCRIPTION
This seems to fix the WebWorker tests on travis. I'm guessing `webworkify` v1.4.0 doesn't work with node 4 (not verified).