### PR TITLE
Support timeout option in http.request

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ the server.
 * `message.trailers` and `message.rawTrailers` will remain empty.
 * Redirects are followed silently by the browser, so it isn't possible to access the 301/302
 redirect pages.
+* The `timeout` options in the `request` method is non-operational in Safari <= 5 and
+Opera <= 12.
 
 ## Example
 
@@ -101,11 +103,11 @@ redirect pages.
 http.get('/bundle.js', function (res) {
 	var div = document.getElementById('result');
 	div.innerHTML += 'GET /beep<br>';
-	
+
 	res.on('data', function (buf) {
 		div.innerHTML += buf;
 	});
-	
+
 	res.on('end', function () {
 		div.innerHTML += '<br>__END__';
 	});

--- a/lib/request.js
+++ b/lib/request.js
@@ -38,8 +38,9 @@ var ClientRequest = module.exports = function (opts) {
 
 	var preferBinary
 	var useFetch = true
-	if (opts.mode === 'disable-fetch') {
-		// If the use of XHR should be preferred and includes preserving the 'content-type' header
+	if (opts.mode === 'disable-fetch' || 'timeout' in opts) {
+		// If the use of XHR should be preferred and includes preserving the 'content-type' header.
+		// Force XHR to be used since the Fetch API does not yet support timeouts.
 		useFetch = false
 		preferBinary = true
 	} else if (opts.mode === 'prefer-streaming') {
@@ -148,6 +149,13 @@ ClientRequest.prototype._onFinish = function () {
 
 		if (self._mode === 'text' && 'overrideMimeType' in xhr)
 			xhr.overrideMimeType('text/plain; charset=x-user-defined')
+
+		if ('timeout' in opts) {
+			xhr.timeout = opts.timeout
+			xhr.ontimeout = function () {
+				self.emit('timeout')
+			}
+		}
 
 		Object.keys(headersObj).forEach(function (name) {
 			xhr.setRequestHeader(headersObj[name].name, headersObj[name].value)

--- a/test/browser/timeout.js
+++ b/test/browser/timeout.js
@@ -1,0 +1,24 @@
+var test = require('tape')
+
+var http = require('../..')
+
+var skipTimeout = ((browserName === 'Opera' && browserVersion <= 12) ||
+    (browserName === 'Safari' && browserVersion <= 5))
+
+
+test('emits timeout events', function (t) {
+    if (skipTimeout) {
+        return t.skip('Browser does not support setting timeouts')
+    }
+
+    var req = http.request({
+        path: '/basic.txt',
+        timeout: 1
+    })
+
+    req.on('timeout', function () {
+        t.end() // the test will timeout if this does not happen
+    })
+
+    req.end()
+})


### PR DESCRIPTION
As seen in [Node 6.8.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V6.md#2016-10-12-version-680-current-fishrock123), `http.request` now supports a `timeout` option. This PR adds support for that in stream-http! Unfortunately we have to force XHR since the Fetch API [does not support timeouts](https://github.com/whatwg/fetch/issues/20) (yet).
