### PR TITLE
Add payload for Microsoft Azure Storage MERGE method

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -98,7 +98,7 @@ ClientRequest.prototype._onFinish = function () {
 
 	var headersObj = self._headers
 	var body
-	if (opts.method === 'POST' || opts.method === 'PUT' || opts.method === 'PATCH') {
+	if (opts.method === 'POST' || opts.method === 'PUT' || opts.method === 'PATCH' || opts.method === 'MERGE') {
 		if (capability.blobConstructor) {
 			body = new global.Blob(self._body.map(function (buffer) {
 				return toArrayBuffer(buffer)


### PR DESCRIPTION
In Microsoft Azure Storage Table REST Services, merging entity depends on the HTTP MERGE method as well as the payload.

Current version of stream-http doesn't make up payload for MERGE method. Add the payload support for MERGE method.

### Related resources:

The Merge Entity operation updates an existing entity by updating the entity's properties. This operation does not replace the existing entity, as the Update Entity operation does.

https://msdn.microsoft.com/en-us/library/azure/dd179392.aspx