### PR TITLE
Adding support for Service Workers.

### DIFF
--- a/lib/capability.js
+++ b/lib/capability.js
@@ -6,12 +6,19 @@ try {
 	exports.blobConstructor = true
 } catch (e) {}
 
-var xhr = new global.XMLHttpRequest()
-// If XDomainRequest is available (ie only, where xhr might not work
-// cross domain), use the page location. Otherwise use example.com
-xhr.open('GET', global.XDomainRequest ? '/' : 'https://example.com')
+// Service workers don't have XHR
+if (global.XMLHttpRequest) {
+	var xhr = new global.XMLHttpRequest()
+	// If XDomainRequest is available (ie only, where xhr might not work
+	// cross domain), use the page location. Otherwise use example.com
+	xhr.open('GET', global.XDomainRequest ? '/' : 'https://example.com')
+} else {
+	var xhr = null
+}
+
 
 function checkTypeSupport (type) {
+	if (!xhr) return false
 	try {
 		xhr.responseType = type
 		return xhr.responseType === type
@@ -30,7 +37,7 @@ exports.arraybuffer = haveArrayBuffer && checkTypeSupport('arraybuffer')
 exports.msstream = !exports.fetch && haveSlice && checkTypeSupport('ms-stream')
 exports.mozchunkedarraybuffer = !exports.fetch && haveArrayBuffer &&
 	checkTypeSupport('moz-chunked-arraybuffer')
-exports.overrideMimeType = isFunction(xhr.overrideMimeType)
+exports.overrideMimeType = xhr ? isFunction(xhr.overrideMimeType) : false
 exports.vbArray = isFunction(global.VBArray)
 
 function isFunction (value) {


### PR DESCRIPTION
For some reason Service Workers have `fetch` but not `XMLHttpRequest`. This fixes it.