### PR TITLE
if xhr.open throws, then no xhr is allowed

### DIFF
--- a/lib/capability.js
+++ b/lib/capability.js
@@ -2,28 +2,33 @@ exports.fetch = isFunction(global.fetch) && isFunction(global.ReadableStream)
 
 exports.blobConstructor = false
 try {
-	new Blob([new ArrayBuffer(1)])
-	exports.blobConstructor = true
+  new Blob([new ArrayBuffer(1)])
+  exports.blobConstructor = true
 } catch (e) {}
 
 // Service workers don't have XHR
 if (global.XMLHttpRequest) {
-	var xhr = new global.XMLHttpRequest()
-	// If XDomainRequest is available (ie only, where xhr might not work
-	// cross domain), use the page location. Otherwise use example.com
-	xhr.open('GET', global.XDomainRequest ? '/' : 'https://example.com')
+  var xhr = new global.XMLHttpRequest()
+  // If XDomainRequest is available (ie only, where xhr might not work
+  // cross domain), use the page location. Otherwise use example.com
+  // Note: this doesn't actually make an http request.
+  try {
+    xhr.open('GET', global.XDomainRequest ? '/' : 'https://example.com')
+  } catch(_) {
+    xhr = null
+  }
 } else {
-	var xhr = null
+  var xhr = null
 }
 
 
 function checkTypeSupport (type) {
-	if (!xhr) return false
-	try {
-		xhr.responseType = type
-		return xhr.responseType === type
-	} catch (e) {}
-	return false
+  if (!xhr) return false
+  try {
+    xhr.responseType = type
+    return xhr.responseType === type
+  } catch (e) {}
+  return false
 }
 
 // For some strange reason, Safari 7.0 reports typeof global.ArrayBuffer === 'object'.
@@ -36,7 +41,7 @@ exports.arraybuffer = haveArrayBuffer && checkTypeSupport('arraybuffer')
 // be used if it's available, just return false for these to avoid the warnings.
 exports.msstream = !exports.fetch && haveSlice && checkTypeSupport('ms-stream')
 exports.mozchunkedarraybuffer = !exports.fetch && haveArrayBuffer &&
-	checkTypeSupport('moz-chunked-arraybuffer')
+  checkTypeSupport('moz-chunked-arraybuffer')
 exports.overrideMimeType = xhr ? isFunction(xhr.overrideMimeType) : false
 exports.vbArray = isFunction(global.VBArray)
 


### PR DESCRIPTION
this handles cases where `xhr.open` throws as in https://github.com/jhiesey/stream-http/issues/60
and https://github.com/ssbc/patchwork/issues/431 other cases should work as before.