### PR TITLE
Catching fetch `read()` errors

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -228,6 +228,10 @@ ClientRequest.prototype._connect = function () {
 		return
 
 	self._response = new IncomingMessage(self._xhr, self._fetchResponse, self._mode)
+	self._response.on('error', function(err) {
+		self.emit('error', err)
+	})
+
 	self.emit('response', self._response)
 }
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -53,6 +53,8 @@ var IncomingMessage = exports.IncomingMessage = function (xhr, response, mode) {
 				}
 				self.push(new Buffer(result.value))
 				read()
+			}).catch(function(err) {
+				self.emit('error', err)
 			})
 		}
 		read()


### PR DESCRIPTION
Errors that occur while reading from the ReadableStream that is returned as part of a `fetch` request were not handled. This change propagates these errors up to the `ClientRequest`.

Thoughts / comments / concerns welcome.