### PR TITLE
Fixed - IE 10/11 will add 'undefined' body for HTTP DELETE

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -185,7 +185,17 @@ ClientRequest.prototype._onFinish = function () {
 		}
 
 		try {
-			xhr.send(body)
+			if (typeof body !== 'undefined') {
+				xhr.send(body);
+			} else {
+				// The XMLHttpRequest specification does not explicitly define `send(undefined)`, but `send()`
+				// or `send(null)` are accepted. While most browsers treat `undefined` and `null` as acceptable,
+				// IE 10/11 convert `undefined` into the body "undefined" with text/plain as the content type.
+				//
+				// XMLHttpRequest Level 1: http://www.w3.org/TR/XMLHttpRequest/#the-send()-method
+				// XMLHttpRequest Living Standard: https://xhr.spec.whatwg.org/#the-send()-method
+				xhr.send();
+			}
 		} catch (err) {
 			process.nextTick(function () {
 				self.emit('error', err)


### PR DESCRIPTION
Fixes an issue where would call XMLHttpRequest.send(undefined), causing an issue in Internet Explorer 10 and 11. In these browsers, XMLHttpRequest.send(undefined) will cause a request body of "undefined" to be sent by the browser (e.g. on a DELETE). This causes the XMLHttpRequest to assume a request body of type text/plain (as Content-Type), which confuses some server software (Such as Azure Storage Server Authorization Error).

There also are same IE issues for other projects, including angular.js.
- [https://github.com/ArcBees/GWTP/issues/584](https://github.com/ArcBees/GWTP/issues/584)
- [https://github.com/angular/angular.js/issues/12141](https://github.com/angular/angular.js/issues/12141)
