### PR TITLE
fix getHeader when header isn't available

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -81,8 +81,10 @@ ClientRequest.prototype.setHeader = function (name, value) {
 }
 
 ClientRequest.prototype.getHeader = function (name) {
-	var self = this
-	return self._headers[name.toLowerCase()].value
+	var header = this._headers[name.toLowerCase()]
+	if (header)
+		return header.value
+	return null
 }
 
 ClientRequest.prototype.removeHeader = function (name) {


### PR DESCRIPTION
more testing need to happen with a module that is required by default in something as large as webpack