### PR TITLE
Allow setting User-Agent Header

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -323,6 +323,5 @@ var unsafeHeaders = [
 	'trailer',
 	'transfer-encoding',
 	'upgrade',
-	'user-agent',
 	'via'
 ]


### PR DESCRIPTION
The User-Agent header has not been forbidden since Firefox 43 (see https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name).

> Note: The User-Agent header is no longer forbidden, as per spec — see forbidden header name list (this was implemented in Firefox 43) — it can now be set in a Fetch Headers object, or via XHR setRequestHeader().

I've had success setting it in Firefox and Edge (edit: and Safari) for `fetch` and it should work for XMLHttpRequest as well but I'm too lazy to look up how to use XMLHttpRequest. I haven't had any luck setting User-Agent it in Chrome yet - may be a Chrome bug - but I'm not seeing any warnings in the terminal when I use it either, so I don't think allowing it will cause any spurious warnings.

fixes: #90