### PR TITLE
Fix IPv6 hostname normalization

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,9 @@ http.request = function (opts, cb) {
 	var path = opts.path || '/'
 
 	// Necessary for IPv6 addresses
-	if (host && host.indexOf(':') !== -1)
-		host = '[' + host + ']'
+	if (host && host === opts.hostname && host.indexOf(':') !== -1 && host.indexOf('[') !== 0) {
+	  host = '[' + host + ']'
+	}
 
 	// This may be a relative url. The browser should always be able to interpret it correctly.
 	opts.url = (host ? (protocol + '//' + host) : '') + (port ? ':' + port : '') + path

--- a/test/node/http-browserify.js
+++ b/test/node/http-browserify.js
@@ -121,9 +121,50 @@ test('Test withCredentials param', function(t) {
 	t.end()
 })
 
-test('Test ipv6 address', function(t) {
+test('Test ipv6 address as string', function(t) {
 	var testUrl = 'http://[::1]:80/foo'
 	var request = http.get(testUrl, noop)
+
+	var resolved = url.resolve(location, request._opts.url)
+	t.equal(resolved, 'http://[::1]:80/foo', 'Url should be correct')
+	t.end()
+})
+
+test('Test ipv6 address as opts with hostname [brackets] and port', function(t) {
+	var opts = {
+		protocol: "http:",
+		hostname: "[::1]",
+		port: "80",
+		path: "/foo"
+	}
+	var request = http.get(opts, noop)
+
+	var resolved = url.resolve(location, request._opts.url)
+	t.equal(resolved, 'http://[::1]:80/foo', 'Url should be correct')
+	t.end()
+})
+
+test('Test ipv6 address as opts with hostname [no brackets] and port', function(t) {
+	var opts = {
+		protocol: "http:",
+		hostname: "::1",
+		port: "80",
+		path: "/foo"
+	}
+	var request = http.get(opts, noop)
+
+	var resolved = url.resolve(location, request._opts.url)
+	t.equal(resolved, 'http://[::1]:80/foo', 'Url should be correct')
+	t.end()
+})
+
+test('Test ipv6 address as opts with host', function(t) {
+	var opts = {
+		protocol: "http:",
+		host: "[::1]:80",
+		path: "/foo"
+	}
+	var request = http.get(opts, noop)
 
 	var resolved = url.resolve(location, request._opts.url)
 	t.equal(resolved, 'http://[::1]:80/foo', 'Url should be correct')


### PR DESCRIPTION
The old check effectively merged the meaning of `host` and `hostname`, which was prone to
errors for multiple reasons:
- in rare scenarios `host` could include `:` but be ipv4 (eg. `127.0.0.1:8080`) which would produce false-positives
- ipv6 could already have square brackets(`[::1]`), but normalization would run anyway and produced invalid URIs like `http://[[::1]]:80`
  - this caused issues like [example in the wild](https://user-images.githubusercontent.com/333031/51712146-d908dd80-1ffb-11e9-9be9-5ba0d63036ed.png)

This changes ipv6 normalization to only run if actual `hostname` parameter is
provided, includes `:` and does not start with `[`. Also, added missing tests for ipv6.

cc #18, https://github.com/ipfs-shipyard/ipfs-companion/issues/668