### PR TITLE
use queueMicrotask

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -2,6 +2,9 @@ var capability = require('./capability')
 var inherits = require('inherits')
 var response = require('./response')
 var stream = require('readable-stream')
+var queueMicrotask = typeof Promise !== 'undefined'
+	? require('queue-microtask')
+	: process.nextTick
 
 var IncomingMessage = response.IncomingMessage
 var rStates = response.readyStates
@@ -154,7 +157,7 @@ ClientRequest.prototype._onFinish = function () {
 		try {
 			xhr.open(self._opts.method, self._opts.url, true)
 		} catch (err) {
-			process.nextTick(function () {
+			queueMicrotask(function () {
 				self.emit('error', err)
 			})
 			return
@@ -207,7 +210,7 @@ ClientRequest.prototype._onFinish = function () {
 		try {
 			xhr.send(body)
 		} catch (err) {
-			process.nextTick(function () {
+			queueMicrotask(function () {
 				self.emit('error', err)
 			})
 			return

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,6 +1,9 @@
 var capability = require('./capability')
 var inherits = require('inherits')
 var stream = require('readable-stream')
+var queueMicrotask = typeof Promise !== 'undefined'
+	? require('queue-microtask')
+	: process.nextTick
 
 var rStates = exports.readyStates = {
 	UNSENT: 0,
@@ -22,8 +25,8 @@ var IncomingMessage = exports.IncomingMessage = function (xhr, response, mode, f
 
 	// Fake the 'close' event, but only once 'end' fires
 	self.on('end', function () {
-		// The nextTick is necessary to prevent the 'request' module from causing an infinite loop
-		process.nextTick(function () {
+		// The queueMicrotask is necessary to prevent the 'request' module from causing an infinite loop
+		queueMicrotask(function () {
 			self.emit('close')
 		})
 	})
@@ -34,7 +37,7 @@ var IncomingMessage = exports.IncomingMessage = function (xhr, response, mode, f
 		self.url = response.url
 		self.statusCode = response.status
 		self.statusMessage = response.statusText
-		
+
 		response.headers.forEach(function (header, key){
 			self.headers[key.toLowerCase()] = header
 			self.rawHeaders.push(key, header)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "builtin-status-codes": "^3.0.0",
     "inherits": "^2.0.4",
+    "queue-microtask": "^1.2.2",
     "readable-stream": "^3.6.0",
     "xtend": "^4.0.2"
   },

--- a/test/browser/abort.js
+++ b/test/browser/abort.js
@@ -1,6 +1,9 @@
 var Buffer = require('buffer').Buffer
 var fs = require('fs')
 var test = require('tape')
+var queueMicrotask = typeof Promise !== 'undefined'
+	? require('queue-microtask')
+	: process.nextTick
 
 var http = require('../..')
 
@@ -43,7 +46,7 @@ test('abort on data', function (t) {
 				firstData = false
 				req.abort()
 				t.end()
-				process.nextTick(function () {
+				queueMicrotask(function () {
 					// Wait for any data that may have been queued
 					// in the stream before considering data events
 					// as errors


### PR DESCRIPTION
The 	queueMicrotask package works in any environment that supports `Promise`. I kept `process.nextTick` for IE11. It will increase the bundle size in other environments but that's okay until/if this package drops IE11 support.